### PR TITLE
add scarthgap to the compat list

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_cyclonedx = "^${LAYERDIR}/"
 BBFILE_PATTERN_IGNORE_EMPTY_cyclonedx = "1"
 
 LAYERDEPENDS_cyclonedx = "core"
-LAYERSERIES_COMPAT_cyclonedx = "styhead"
+LAYERSERIES_COMPAT_cyclonedx = "styhead scarthgap"


### PR DESCRIPTION
As it's compatible out fo the box.

(still looking to make this work with kirkstone)