### PR TITLE
Update layer.conf to add Wrynose compatibility

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_cyclonedx = "^${LAYERDIR}/"
 BBFILE_PATTERN_IGNORE_EMPTY_cyclonedx = "1"
 
 LAYERDEPENDS_cyclonedx = "core"
-LAYERSERIES_COMPAT_cyclonedx = "styhead scarthgap"
+LAYERSERIES_COMPAT_cyclonedx = "styhead scarthgap wrynose"


### PR DESCRIPTION
This layer can be built using Poky Wrynose just by updating the layer compatibility

Connects-to: https://github.com/balena-os/meta-balena/pull/3844